### PR TITLE
Adjusted EBI - LSF configuration.

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -92,6 +92,8 @@ profiles {
         executor {
             name = "lsf"
             queueSize = 200
+            submitRateLimit = "10 sec"
+            pollInterval = "10 sec"
         }
         process.cache = "lenient"
 
@@ -102,7 +104,7 @@ profiles {
         }
 
         process {
-            errorStrategy = 'finish'
+            errorStrategy = {task.attempt <= 2 ? 'retry' : 'finish'}
             queue = 'production'
             withLabel: process_bigmem {
                 queue = 'bigmem'


### PR DESCRIPTION
Limit job submission and queue size, to avoid flooding LSF.
Retry tasks at least twice.