### PR TITLE
Prevent generate_extra_weight_table.py from bailing out if a genome is missing.

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -92,6 +92,8 @@ profiles {
         executor {
             name = "lsf"
             queueSize = 200
+            submitRateLimit = "10 sec"
+            pollInterval = "10 sec"
         }
         process.cache = "lenient"
 
@@ -102,7 +104,7 @@ profiles {
         }
 
         process {
-            errorStrategy = 'finish'
+            errorStrategy = {task.attempt <= 2 ? 'retry' : 'finish'}
             queue = 'production'
             withLabel: process_bigmem {
                 queue = 'bigmem'


### PR DESCRIPTION
Missing genomes at this step may have been removed in the QC step.