### PR TITLE
Removed splitting scaffolds into contigs

### DIFF
--- a/bin/assembly_stats.py
+++ b/bin/assembly_stats.py
@@ -44,16 +44,15 @@ def read_genome(fasta_file):
     total_len = 0
     contig_lens = []
     for _, seq in fasta_iter(fasta_file):
-        if "NN" in seq:
-            contig_list = seq.split("NN")
-        else:
-            contig_list = [seq]
+        contig_list = [seq]
         for contig in contig_list:
             if len(contig):
                 gc += contig.count("G") + contig.count("C")
                 total_len += len(contig)
                 contig_lens.append(len(contig))
-    gc_cont = (gc / total_len) * 100
+    gc_cont = round((gc / total_len) * 100, 2)
+    if gc_cont.is_integer():
+        gc_cont = int(gc_cont)
     return contig_lens, gc_cont
 
 


### PR DESCRIPTION
Stats calculation fix - the original script split contigs into multiple ones if "N" was present. Removed this feature.