### PR TITLE
Increate memory and cpus in some tools for largue catalogues.

### DIFF
--- a/config/codon.config
+++ b/config/codon.config
@@ -54,7 +54,7 @@ process {
         cpus = 8; memory = { 12.GB * task.attempt }
     }
     withName: IQTREE {
-        cpus = 8; memory = { 20.GB * task.attempt }
+        cpus = 32; memory = { 20.GB * task.attempt }
     }
     withName: KRAKEN2_BUILD {
         cpus = 4

--- a/config/codon_xlarge.config
+++ b/config/codon_xlarge.config
@@ -57,10 +57,10 @@ process {
         cpus = 8; memory = { 12.GB * task.attempt }
     }
     withName: IQTREE {
-        cpus = 8; memory = { 100.GB * task.attempt }
+        cpus = 32; memory = { 100.GB * task.attempt }
     }
     withName: KRAKEN2_BUILD {
-        cpus = 4; memory = { 1.GB * task.attempt }
+        cpus = 4; memory = { 10.GB * task.attempt }
     }
     withName: MASH_COMPARE {
         cpus = 1; memory = { 1.GB * task.attempt }
@@ -75,13 +75,13 @@ process {
         cpus = 1; memory = { 1.GB * task.attempt }
     }
     withName: METADATA_TABLE {
-        cpus = 1; memory = { 1.GB * task.attempt }
+        cpus = 1; memory = { 6.GB * task.attempt }
     }
     withName: MMSEQ {
         cpus = 32; memory = { 500.GB * task.attempt }
     }
     withName: PANAROO {
-        cpus = 8; memory = { 3.GB * task.attempt }
+        cpus = 8; memory = { 12.GB * task.attempt }
     }
     withName: PER_GENOME_ANNONTATION_GENERATOR {
         cpus = 16;

--- a/modules/iqtree.nf
+++ b/modules/iqtree.nf
@@ -25,7 +25,7 @@ process IQTREE {
     """
     gunzip -c ${msa_fasta_gz} > ${output_prefix}_alignment.faa
 
-    iqtree -T 8 \
+    iqtree -T AUTO -ntmax ${task.cpus} \
     -s ${output_prefix}_alignment.faa \
     --prefix iqtree.${output_prefix}
 


### PR DESCRIPTION
For IQTree bump to 32 cpus, but use the AUTO + max cpus flags.