### PR TITLE
Fix/trna detect nfs tmp

### DIFF
--- a/modules/detect_trna.nf
+++ b/modules/detect_trna.nf
@@ -37,13 +37,15 @@ process DETECT_TRNA {
 
     script:
     """
+    # TODO: We should migrate to https://github.com/nf-core/modules/blob/master/modules/nf-core/trnascanse/main.nf
+
     shopt -s extglob
 
     # tRNAscan-SE needs a tmp folder otherwise it will use the base TMPDIR (with no subfolder)
     # and that causes issues as other detect_trna process will crash when the files are cleaned
     export PROCESSTMP="\$(mktemp -d)"
     export TMPDIR="\${PROCESSTMP}"
-    
+   
     # Cleanup on exit, but ignore .nfs* files
     trap '
         if [ -d "\${PROCESSTMP}" ]; then
@@ -56,11 +58,12 @@ process DETECT_TRNA {
 
     echo "[ Detecting tRNAs ]"
     kingdom=\$(echo ${detected_kingdom} | cut -c1)
-    tRNAscan-SE -\${kingdom} -Q \
-    -m ${genome_name}_stats.out \
-    -o ${genome_name}_trna.out \
-    --gff ${genome_name}_trna.gff \
-    ${fasta}
+    tRNAscan-SE -\${kingdom} -Q \\
+      -m ${genome_name}_stats.out \\
+      -o ${genome_name}_trna.out \\
+      --gff ${genome_name}_trna.gff \\
+      --thread ${task.cpus} \\
+      ${fasta}
 
     parse_tRNA.py -i ${genome_name}_stats.out -o ${genome_name}_tRNA_20aa.out
 

--- a/modules/detect_trna.nf
+++ b/modules/detect_trna.nf
@@ -41,10 +41,18 @@ process DETECT_TRNA {
 
     # tRNAscan-SE needs a tmp folder otherwise it will use the base TMPDIR (with no subfolder)
     # and that causes issues as other detect_trna process will crash when the files are cleaned
-    PROCESSTMP="\$(mktemp -d)"
+    export PROCESSTMP="\$(mktemp -d)"
     export TMPDIR="\${PROCESSTMP}"
-    # bash trap to clean the tmp directory
-    trap 'rm -r -- "\${PROCESSTMP}"' EXIT
+    
+    # Cleanup on exit, but ignore .nfs* files
+    trap '
+        if [ -d "\${PROCESSTMP}" ]; then
+           # Remove everything except .nfs* files
+           find "\${PROCESSTMP}" -mindepth 1 ! -name ".nfs*" -exec rm -rf {} +
+           # Try removing the directory (will fail if .nfs files remain, which is fine)
+           rmdir "\${PROCESSTMP}" 2>/dev/null || true
+        fi
+    ' EXIT
 
     echo "[ Detecting tRNAs ]"
     kingdom=\$(echo ${detected_kingdom} | cut -c1)


### PR DESCRIPTION
Fixing issue:
```
 ------------------------------------------------------------
 Sequence file(s) to search:    MGYG000519425.fna
 Search Mode:            Bacterial
 Results written to:        MGYG000519425_trna.out
 Output format:           Tabular
 Searching with:          Infernal First Pass->Infernal
 Isotype-specific model scan:    Yes
 Covariance model:         /opt/conda/lib/tRNAscan-SE/models/TRNAinf-bact.cm
                   /opt/conda/lib/tRNAscan-SE/models/TRNAinf-bact-SeC.cm
 Infernal first pass cutoff score: 10
  
 Temporary directory:        /hps/nobackup/rdf/metagenomics/service-team/nextflow-workdir/users/kates/tmp.8sFIpgYEKe
 tRNA predictions saved to:     MGYG000519425_trna.gff
 Search statistics saved in:    MGYG000519425_stats.out
 ------------------------------------------------------------
  
 rm: cannot remove '/hps/nobackup/rdf/metagenomics/service-team/nextflow-workdir/users/kates/tmp.8sFIpgYEKe/.nfs0b88441b8983854300057e22': No such file or directory
```