### PR TITLE
EMG-7798 Various fixes for euk workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ Detailed information about existing MGnify catalogues: https://docs.mgnify.org/s
 | samtools                                                                                         | 1.15             | FASTA indexing                                                                                                         |
 | EukCC                                                                                            | 2.1.3            | Completeness and contamination of eukaryotic genomes                                                                   |
 | BUSCO                                                                                            | 5.8.0            | Eukaryotic genome quality                                                                                              |
-| RepeatModeler                                                                                    | 2.0.6            | Identification of repeat elements in eukaryotic genomes                                                                |
-| RepeatMasker                                                                                     | 4.1.7            | Repeat masking in eukaryotic genomes                                                                                   |
+| RepeatModeler                                                                                    | 2.0.7            | Identification of repeat elements in eukaryotic genomes                                                                |
+| RepeatMasker                                                                                     | 4.2.3            | Repeat masking in eukaryotic genomes                                                                                   |
 | Braker                                                                                           | 3.0.8            | Gene calling in eukaryotic genomes                                                                                     |
+| Datascout                                                                                        | 1.1.0            | Query and fetch protein evidence for eukaryotic gene prediction                                                        |
+
 
 ## Setup
 
@@ -133,7 +135,7 @@ performs the following:
 
 While a regular pipeline execution uses dRep to cluster genomes, **the clustering during the update process is different in the following ways**:
 
-- existing clustering from the previous catalogue version is preserved 
+- existing clustering from the previous catalogue version is preserved
 - the genomes that are flagged for removal (by the user or the pipeline) are removed without disrupting the existing clusters
 - if new genomes are being added, their placement is determined using [Mash](https://github.com/marbl/Mash) and the following rules:
   1. if the smallest Mash distance between the new genome and any of the existing catalogue genomes is less than 0.001, the new genome is classified as a repeat strain
@@ -143,14 +145,14 @@ While a regular pipeline execution uses dRep to cluster genomes, **the clusterin
   5. new strains and new species are always added to the catalogue, as long as they pass the general quality control checks used for new genomes
 
 ### Quality comparisons for new genomes
-During the catalogue cluster update process, the quality scores for all genomes are calculated as:  
-`QS = % completeness – 5 * % contamination + 0.5 * log(N50)`  
-A 10% quality improvement is computed as `threshold = QS * 1.1`.  
+During the catalogue cluster update process, the quality scores for all genomes are calculated as:
+`QS = % completeness – 5 * % contamination + 0.5 * log(N50)`
+A 10% quality improvement is computed as `threshold = QS * 1.1`.
 The quality score improvement is used to decide:
 - if a repeat strain should be added to the catalogue
 - if the species representative genome should be re-assigned.
 
-For threshold values <= 100, the highest quality genome above the threshold is chosen as the new representative.  
+For threshold values <= 100, the highest quality genome above the threshold is chosen as the new representative.
 If threshold > 100, the decision process changes to prioritise genome contiguity. The species representative is replaced if there is a genome that satisfies the following conditions:
 - QS and completeness is same or higher than the existing rep
 - Contamination is the same or less than the existing rep

--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ Detailed information about existing MGnify catalogues: https://docs.mgnify.org/s
 | RepeatModeler                                                                                    | 2.0.7            | Identification of repeat elements in eukaryotic genomes                                                                |
 | RepeatMasker                                                                                     | 4.2.3            | Repeat masking in eukaryotic genomes                                                                                   |
 | Braker                                                                                           | 3.0.8            | Gene calling in eukaryotic genomes                                                                                     |
-
+| CAT_pack                                                                                         | 5.2.3            | Taxonomic classification of eukaryotic genomes                                                                         |
+| CAT_pack DB                                                                                      | 2021-01-07       | DIAMOND database made from NCBI nr and NCBI taxdump used by CAT_pack                                                   |
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ Detailed information about existing MGnify catalogues: https://docs.mgnify.org/s
 | RepeatModeler                                                                                    | 2.0.7            | Identification of repeat elements in eukaryotic genomes                                                                |
 | RepeatMasker                                                                                     | 4.2.3            | Repeat masking in eukaryotic genomes                                                                                   |
 | Braker                                                                                           | 3.0.8            | Gene calling in eukaryotic genomes                                                                                     |
-| Datascout                                                                                        | 1.1.0            | Query and fetch protein evidence for eukaryotic gene prediction                                                        |
 
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ cd containers && bash build.sh
  - catalogue biome (for example, root:Host-associated:Human:Digestive system:Large intestine:Fecal)
  - min and max accession number to be assigned to the genomes (only MGnify specific). Max - Min = #total number of genomes (NCBI+ENA)
 
+### Eukaryotic genomes: protein evidence for gene prediction
+
+If you are running the pipeline with `--kingdom eukaryotes`, you need to collect protein evidence before running the pipeline. This evidence is used by [Braker](https://github.com/Gaius-Augustus/BRAKER) for gene prediction.
+
+Use [datascout](https://github.com/EBI-Metagenomics/datascout) pipeline to collect the required protein data from OrthoDB:
+
+```bash
+nextflow run datascout/main.nf --samplesheet <datascout_input>.csv --download_rna_fastq false
+```
+
+The samplesheet with protein evidence should be supplied with `--protein_evidence` parameter. The expected format is a CSV file with two columns — `genome` and `proteins` — mapping each genome filename to its corresponding protein FASTA file. See [assets/datascout_samplesheet.csv](assets/datascout_samplesheet.csv) for an example.
+
 ## Execution
 
 The pipeline is built in [Nextflow](https://www.nextflow.io), and utilized containers to run the software (we don't support conda ATM).

--- a/assets/datascout_samplesheet.csv
+++ b/assets/datascout_samplesheet.csv
@@ -1,0 +1,4 @@
+genome,proteins
+GCA_963974035.fa,/path/to/datascout_output/GCA_963974035_orthodb_dir/92860_sequences/combined_orthodb_92860.faa
+GCA_963976495.fa,/path/to/datascout_output/GCA_963976495_orthodb_dir/5178_sequences/combined_orthodb_5178.faa
+GCA_963979565.fa,/path/to/datascout_output/GCA_963979565_orthodb_dir/13792_sequences/combined_orthodb_13792.faa

--- a/bin/create_metadata_table.py
+++ b/bin/create_metadata_table.py
@@ -19,17 +19,23 @@
 import argparse
 import logging
 import os
-import pandas as pd
 import re
 import sys
-
 from itertools import chain
 
+import pandas as pd
 from assembly_stats import run_assembly_stats
 
 logging.basicConfig(level=logging.INFO)
 
-UNINFORMATIVE = {"not collected", "not present", "na", "n/a", "missing", "not applicable"}
+UNINFORMATIVE = {
+    "not collected",
+    "not present",
+    "na",
+    "n/a",
+    "missing",
+    "not applicable",
+}
 
 
 def main(
@@ -50,15 +56,20 @@ def main(
     busco_output,
     euk=False,
 ):
-    # table_columns = ['Genome', 'Genome_type', 'Length', 'N_contigs', 'N50',	'GC_content',
-    #           'Completeness', 'Contamination', 'rRNA_5S', 'rRNA_16S', 'rRNA_23S', 'tRNAs', 'Genome_accession',
-    #           'Species_rep', 'MGnify_accession', 'Lineage', 'Sample_accession', 'Study_accession', 'Country',
-    #           'Continent', 'FTP_download']
+    # table_columns = ['Genome', 'Genome_type', 'Length', 'N_contigs', 'N50', 'GC_content',
+    #           'Completeness', 'Contamination', 'rRNA_5S', 'rRNA_16S', 'rRNA_23S',
+    #           'tRNAs', 'Genome_accession',
+    #           'Species_rep', 'MGnify_accession', 'Lineage', 'Sample_accession',
+    #           'Study_accession', 'Country', 'Continent', 'FTP_download']
     genome_list, genomes_ext = load_genome_list(genomes_dir, gunc_failed)
     logging.info("Loaded genome list")
     if previous_metadata_table:
-        logging.info("Loading data from the previous catalogue version's metadata table")
-        previous_version_data = load_previous_metadata_table(previous_metadata_table, genome_list)
+        logging.info(
+            "Loading data from the previous catalogue version's metadata table"
+        )
+        previous_version_data = load_previous_metadata_table(
+            previous_metadata_table, genome_list
+        )
     else:
         previous_version_data = pd.DataFrame()
     df = pd.DataFrame(genome_list, columns=["Genome"])
@@ -91,15 +102,19 @@ def add_busco(df, busco_output):
         "F": "Fragmented",
         "M": "Missing",
         "n": "Total BUSCOs",
-        "E": "Erroneous"
+        "E": "Erroneous",
     }
-    pattern = r'([CSDMFEn]):([\d\.%]+)'
+    pattern = r"([CSDMFEn]):([\d\.%]+)"
     busco_results = dict()
     with open(busco_output, "r") as f:
         for line in f:
             file_name, busco_line = line.strip().split("\t")
             file_name = file_name.replace(".fa", "")
-            converted_busco = re.sub(pattern, lambda m: f"{busco_mapping[m.group(1)]}:{m.group(2) }", busco_line)
+            converted_busco = re.sub(
+                pattern,
+                lambda m: f"{busco_mapping[m.group(1)]}:{m.group(2) }",
+                busco_line,
+            )
             file_name = file_name.replace(".fa", "")
             busco_results[file_name] = converted_busco
     df["BUSCO_quality"] = df["Genome"].map(busco_results)
@@ -107,11 +122,21 @@ def add_busco(df, busco_output):
 
 
 def load_previous_metadata_table(previous_metadata_table, genome_list):
-    columns_to_save = ["Genome", "Sample_accession", "Study_accession", "Country", "Continent"]
-    previous_version_data = pd.read_csv(previous_metadata_table, sep='\t', usecols=columns_to_save)
+    columns_to_save = [
+        "Genome",
+        "Sample_accession",
+        "Study_accession",
+        "Country",
+        "Continent",
+    ]
+    previous_version_data = pd.read_csv(
+        previous_metadata_table, sep="\t", usecols=columns_to_save
+    )
 
     # filter the dataframe to only keep genomes that we are using
-    previous_version_data = previous_version_data[previous_version_data["Genome"].isin(genome_list)]
+    previous_version_data = previous_version_data[
+        previous_version_data["Genome"].isin(genome_list)
+    ]
     return previous_version_data
 
 
@@ -132,27 +157,43 @@ def add_ftp(df, genome_list, catalog_ftp_name, catalog_version, species_reps):
 def add_sample_project_loc(df, location_file, previous_version_data):
     location_data_df = pd.read_csv(
         location_file,
-        sep='\t',
+        sep="\t",
         header=None,
-        names=['Genome_accession', 'Sample_accession', 'Study_accession', 'Country', 'Continent']
+        names=[
+            "Genome_accession",
+            "Sample_accession",
+            "Study_accession",
+            "Country",
+            "Continent",
+        ],
     )
-    df = df.merge(location_data_df, on='Genome_accession', how='left')
+    df = df.merge(location_data_df, on="Genome_accession", how="left")
 
     # If previous version data is available, override where applicable
     # Replace uninformative country/continent with "not provided" as is already done for all new genomes
     if not previous_version_data.empty:
-        prev_data_dict = previous_version_data.set_index("Genome").to_dict(orient="index")
+        prev_data_dict = previous_version_data.set_index("Genome").to_dict(
+            orient="index"
+        )
         for idx, row in df.iterrows():
             genome = row["Genome"]
             if genome in prev_data_dict:
-                for col in ["Sample_accession", "Study_accession", "Country", "Continent"]:
+                for col in [
+                    "Sample_accession",
+                    "Study_accession",
+                    "Country",
+                    "Continent",
+                ]:
                     val = prev_data_dict[genome][col]
                     if col in ["Country", "Continent"]:
-                        if isinstance(val, str) and val.strip().lower() in UNINFORMATIVE:
+                        if (
+                            isinstance(val, str)
+                            and val.strip().lower() in UNINFORMATIVE
+                        ):
                             df.at[idx, col] = "not provided"
                             continue
                     df.at[idx, col] = val
-                    
+
     return df
 
 
@@ -217,28 +258,33 @@ def add_rna(df, genome_list, rna_folder, euk=False):
             "{}_tRNA_20aa.out".format(genome),
         )
         rna_results["tRNAs"][genome] = load_trna(trna_file)
-        (
-            rna_results
-        ) = load_rrna(rrna_file, rna_results, euk=euk)
+        (rna_results) = load_rrna(rrna_file, rna_results, euk=euk)
     for key in chain(rna_types, ["tRNAs"]):
         df[key] = df["Genome"].map(rna_results[key])
     return df
 
 
 def load_rrna(rrna_file, rna_results, euk=False):
-    conversion = {"SSU_rRNA_eukarya": "rRNA_18S",
-                  "LSU_rRNA_eukarya": "rRNA_28S",
-                  "5S_rRNA": "rRNA_5S",
-                  "5_8S_rRNA": "rRNA_5.8S",
-                  "SSU_rRNA": "rRNA_16S",
-                  "LSU_rRNA": "rRNA_23S"}
+    conversion = {
+        "SSU_rRNA_eukarya": "rRNA_18S",
+        "LSU_rRNA_eukarya": "rRNA_28S",
+        "5S_rRNA": "rRNA_5S",
+        "5_8S_rRNA": "rRNA_5.8S",
+        "SSU_rRNA": "rRNA_16S",
+        "LSU_rRNA": "rRNA_23S",
+    }
 
     with open(rrna_file, "r") as file_in:
         for line in file_in:
             genome, rna_type, coverage = line.strip().split("\t")
-            # In the conversion dictionary, prokaryotic SSU and LSU keys are truncated but all the other keys are 
-            # shown in full. The line below checks for this to assign correct conversion.
-            key = rna_type if euk or not rna_type.startswith(("SSU_rRNA", "LSU_rRNA")) else rna_type.rsplit("_", 1)[0]
+            # In the conversion dictionary, prokaryotic SSU and LSU keys are truncated
+            # but all the other keys are shown in full.
+            # The line below checks for this to assign correct conversion.
+            key = (
+                rna_type
+                if euk or not rna_type.startswith(("SSU_rRNA", "LSU_rRNA"))
+                else rna_type.rsplit("_", 1)[0]
+            )
             converted_rna_type = conversion[key]
             rna_results[converted_rna_type][genome] = coverage
     return rna_results
@@ -286,8 +332,9 @@ def calc_assembly_stats(genomes_dir, acc, ext):
 
 def add_precomputed_stats(df, precomputed_genome_stats):
     columns_to_save = ["Genome", "Length", "N_contigs", "N50", "GC_content"]
-    stats = pd.read_csv(precomputed_genome_stats, sep='\t', usecols=columns_to_save)
-    df = df.merge(stats, on="Genome", how="left")  # Left join to keep only existing genomes in df
+    stats = pd.read_csv(precomputed_genome_stats, sep="\t", usecols=columns_to_save)
+    # Left join to keep only existing genomes in df
+    df = df.merge(stats, on="Genome", how="left")
     # reorder columns
     df = df[[col for col in df.columns if col not in columns_to_save] + columns_to_save]
     return df
@@ -313,7 +360,7 @@ def add_genome_type(df, extra_weight_table):
 
 
 def load_genome_list(genomes_dir, gunc_file):
-    genome_list = [filename.rsplit(".", 1)[0].replace("_sm", "") for filename in os.listdir(genomes_dir)]
+    genome_list = [filename.rsplit(".", 1)[0] for filename in os.listdir(genomes_dir)]
     genomes_ext = os.listdir(genomes_dir)[0].rsplit(".", 1)[1]
     if gunc_file and gunc_file != "EMPTY":
         with open(gunc_file, "r") as gunc_in:
@@ -321,7 +368,7 @@ def load_genome_list(genomes_dir, gunc_file):
                 acc = line.strip().split(".")[0]
                 try:
                     genome_list.remove(acc)
-                except:
+                except ValueError:
                     logging.info(
                         "Genome {} failed GUNC and is not present in the genomes"
                         " directory".format(acc)
@@ -427,7 +474,7 @@ def parse_args():
     )
     parser.add_argument(
         "--euk",
-        action='store_true',
+        action="store_true",
         help="Use this flag if the metadata table is being generated for a eukaryotic catalogue.",
     )
     return parser.parse_args()

--- a/bin/rename_fasta.py
+++ b/bin/rename_fasta.py
@@ -19,8 +19,8 @@
 import argparse
 import logging
 import os
-import shutil
 import re
+import shutil
 
 logging.basicConfig(level=logging.INFO)
 
@@ -31,7 +31,9 @@ def read_map_file(map_file):
         for line in file_in:
             line = line.strip().split("\t")
             mapping[line[0]] = line[1]
-    assert len(list(mapping.values())) == len(set(mapping.values())), "Repeat names in file {}".format(map_file)
+    assert len(list(mapping.values())) == len(
+        set(mapping.values())
+    ), "Repeat names in file {}".format(map_file)
     return mapping
 
 
@@ -88,7 +90,12 @@ def main(
                 )
             else:
                 rename_fasta(
-                    file, new_name, fasta_file_directory, rename_deflines, accession, spades_style=spades_style
+                    file,
+                    new_name,
+                    fasta_file_directory,
+                    rename_deflines,
+                    accession,
+                    spades_style=spades_style,
                 )
                 try:
                     os.remove(os.path.join(fasta_file_directory, file))
@@ -121,9 +128,7 @@ def write_fasta(old_path, new_path, accession, spades_style=False):
                     ">{}_{}-length-{}-cov-{}\n".format(accession, n, length, coverage)
                 )
             else:
-                file_out.write(
-                    ">{}_{}\n".format(accession, n)
-                )
+                file_out.write(">{}_{}\n".format(accession, n))
         else:
             file_out.write(line)
     file_in.close()
@@ -138,7 +143,9 @@ def rename_to_outdir(file, new_name, accession, input_dir, output_dir, spades_st
     write_fasta(old_path, new_path, accession, spades_style)
 
 
-def rename_fasta(file, new_name, fasta_file_directory, rename_deflines, accession, spades_style):
+def rename_fasta(
+    file, new_name, fasta_file_directory, rename_deflines, accession, spades_style
+):
     new_path = os.path.join(fasta_file_directory, new_name)
     old_path = os.path.join(fasta_file_directory, file)
     if not rename_deflines:
@@ -181,8 +188,9 @@ def rename_csv(names, csv_file, busco):
         with open(busco, "r") as busco_in, open(busco_renamed, "w") as busco_out:
             for line in busco_in:
                 items = line.strip().split("\t")
-                genome = names[items[0]] if items[0] in names else items[0]
-                busco_out.write("\t".join([genome] + items[1:2]) + "\n")
+                if items[0] not in names:
+                    continue
+                busco_out.write("\t".join([names[items[0]]] + items[1:2]) + "\n")
 
 
 def parse_args():
@@ -253,9 +261,10 @@ def parse_args():
         "--spades-style",
         action="store_true",
         help=(
-            "If this flag is on, deflines within the FASTA file will be named in the format that spades uses: "
-            "{contig_name}-length-{num}-cov-{num}, for example, MGYG00001_1--length--112345--cov--4.7. Without this "
-            "flag, the names will be kept to the contig accession only, for example, MGYG00001_1."
+            "If this flag is on, deflines within the FASTA file will be named in the format "
+            "that spades uses: {contig_name}-length-{num}-cov-{num}, for example, "
+            "MGYG00001_1--length--112345--cov--4.7. Without this flag, the names will be "
+            "kept to the contig accession only, for example, MGYG00001_1."
         ),
     )
     parser.add_argument(
@@ -263,17 +272,17 @@ def parse_args():
         dest="outputdir",
         required=False,
         help="Output directory for renamed FASTA files (use in CWL). "
-             "If specifying outputdir, the deflines in FASTA will also be renamed. "
-             "If outdir is not specified, files will be renamed inside their "
-             "original folder and deflines only renamed if flag --rename-deflines "
-             "is used.",
+        "If specifying outputdir, the deflines in FASTA will also be renamed. "
+        "If outdir is not specified, files will be renamed inside their "
+        "original folder and deflines only renamed if flag --rename-deflines "
+        "is used.",
     )
     parser.add_argument(
         "--csv",
         dest="csv",
         required=False,
         help="CSV file with completeness and contamination. If provided, the genomes inside the file "
-             "will be renamed using their new filenames and saved into a new file.",
+        "will be renamed using their new filenames and saved into a new file.",
     )
 
     parser.add_argument(
@@ -282,7 +291,7 @@ def parse_args():
         required=False,
         default=None,
         help="TSV file with busco scores. If provided, the genomes inside the file "
-             "will be renamed using their new filenames and saved into a new file.",
+        "will be renamed using their new filenames and saved into a new file.",
     )
 
     parser.add_argument(

--- a/config/modules.config
+++ b/config/modules.config
@@ -16,6 +16,16 @@ process {
 }
 
 process {
+    withName: "RENAME_FASTA" {
+        publishDir = [
+            path: "${params.outdir}/additional_data/busco",
+            pattern: "renamed_*.summary",
+            mode: 'copy'
+        ]
+    }
+}
+
+process {
     withName: DREP_CATALOGUE {
         publishDir = [
             path: "${params.outdir}/additional_data/intermediate_files",

--- a/config/modules.config
+++ b/config/modules.config
@@ -29,8 +29,12 @@ process {
 process {
     withName: IPS_PER_GENOME {
         publishDir = [
-            path: "${params.outdir}/interpro",
+            path: {
+                def cluster_rep_prefix = id.substring(0, id.length() - 2)
+                "${params.outdir}/species_catalogue/${cluster_rep_prefix}/${id}/genome/"
+            },
             pattern: "*.IPS.tsv",
+            saveAs: { filename -> "${id}_interpro.tsv" },
             mode: 'copy'
         ]
     }
@@ -39,8 +43,12 @@ process {
 process {
     withName: EGGNOG_MAPPER_ANNOTATIONS_PER_GENOME {
         publishDir = [
-            path:"${params.outdir}/eggnog",
+            path: {
+                def cluster_rep_prefix = id.substring(0, id.length() - 2)
+                "${params.outdir}/species_catalogue/${cluster_rep_prefix}/${id}/genome/"
+            },
             pattern: "*annotations",
+            saveAs: { filename -> "${id}_eggNOG.tsv" },
             mode: 'copy'
         ]
     }

--- a/config/modules.config
+++ b/config/modules.config
@@ -16,16 +16,6 @@ process {
 }
 
 process {
-    withName: "RENAME_FASTA" {
-        publishDir = [
-            path: "${params.outdir}/additional_data/busco",
-            pattern: "renamed_*.summary",
-            mode: 'copy'
-        ]
-    }
-}
-
-process {
     withName: DREP_CATALOGUE {
         publishDir = [
             path: "${params.outdir}/additional_data/intermediate_files",
@@ -111,12 +101,19 @@ process {
 process {
     withName: RENAME_FASTA {
         publishDir = [
-        path: "${params.outdir}/additional_data/intermediate_files",
-        pattern: "*.tsv",
-        saveAs: { "renamed_genomes_name_mapping.tsv" },
-        mode: 'copy',
-        enabled: !params.update_catalogue_path ? true : false,
-        failOnError: true
+            [
+                path: "${params.outdir}/additional_data/intermediate_files",
+                pattern: "*.tsv",
+                saveAs: { "renamed_genomes_name_mapping.tsv" },
+                mode: 'copy',
+                enabled: !params.update_catalogue_path ? true : false,
+                failOnError: true
+            ],
+            [
+                path: "${params.outdir}/additional_data/busco",
+                pattern: "renamed_*.summary",
+                mode: 'copy'
+            ]
         ]
     }
 }

--- a/config/modules.config
+++ b/config/modules.config
@@ -101,19 +101,12 @@ process {
 process {
     withName: RENAME_FASTA {
         publishDir = [
-            [
-                path: "${params.outdir}/additional_data/intermediate_files",
-                pattern: "*.tsv",
-                saveAs: { "renamed_genomes_name_mapping.tsv" },
-                mode: 'copy',
-                enabled: !params.update_catalogue_path ? true : false,
-                failOnError: true
-            ],
-            [
-                path: "${params.outdir}/additional_data/busco",
-                pattern: "renamed_*.summary",
-                mode: 'copy'
-            ]
+            path: "${params.outdir}/additional_data/intermediate_files",
+            pattern: "*.tsv",
+            saveAs: { "renamed_genomes_name_mapping.tsv" },
+            mode: 'copy',
+            enabled: !params.update_catalogue_path ? true : false,
+            failOnError: true
         ]
     }
 }

--- a/modules/braker.nf
+++ b/modules/braker.nf
@@ -21,6 +21,10 @@ process BRAKER {
         args += "--prot_seq ${protein_evidence} "
     }
     """
+    # Make HOME unique for this task; AUGUSTUS will then use \$HOME/.augustus
+    export HOME="\$PWD/.home"
+    mkdir -p "\$HOME"
+
     braker.pl \\
         $args \\
         --genome ${masked_genome} \\

--- a/modules/braker.nf
+++ b/modules/braker.nf
@@ -1,10 +1,7 @@
 process BRAKER {
     tag "${genome_name}"
 
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/braker3:3.0.8--hdfd78af_0' :
-        'quay.io/biocontainers/braker3:3.0.8--hdfd78af_0' }"
-
+    container "docker.io/teambraker/braker3:v3.0.8"
 
     input:
     tuple val(genome_name), path(masked_genome) // genome fasta with softmasked repeat

--- a/modules/braker.nf
+++ b/modules/braker.nf
@@ -2,8 +2,8 @@ process BRAKER {
     tag "${genome_name}"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://teambraker/braker3:latest' :
-        'teambraker/braker3:latest' }"
+        'https://depot.galaxyproject.org/singularity/braker3:3.0.8--hdfd78af_0' :
+        'quay.io/biocontainers/braker3:3.0.8--hdfd78af_0' }"
 
 
     input:

--- a/modules/braker_postprocessing.nf
+++ b/modules/braker_postprocessing.nf
@@ -4,8 +4,16 @@ process BRAKER_POSTPROCESSING {
 
     publishDir(
         path: "${params.outdir}/species_catalogue/${cluster_prefix}/${cluster_name}/genome",
-        pattern: "*.{faa,fna}",
+        pattern: "*.faa",
         saveAs: { filename -> is_rep ? filename : null },
+        mode: 'copy',
+        failOnError: true
+    )
+
+    publishDir(
+        path: "${params.outdir}/species_catalogue/${cluster_prefix}/${cluster_name}/genome",
+        pattern: "${masked_genome.name}",
+        saveAs: { filename -> is_rep ? "${masked_genome.baseName}.fna" : null },
         mode: 'copy',
         failOnError: true
     )
@@ -27,7 +35,7 @@ process BRAKER_POSTPROCESSING {
 
     publishDir(
         path: "${params.outdir}/additional_data/mgyg_genomes",
-        pattern: "*.fna",
+        pattern: "${masked_genome.name}",
         saveAs: { filename -> "${masked_genome.baseName}.fna" },
         mode: 'copy',
         failOnError: true
@@ -46,6 +54,7 @@ process BRAKER_POSTPROCESSING {
     tuple val(genome_name), path(ffn)
 
     output:
+    tuple val(genome_name), path(masked_genome), emit: input_genome
     tuple val(genome_name), path("*.gff"), emit: renamed_gff3
     tuple val(genome_name), path("*.faa"), emit: renamed_proteins
     tuple val(genome_name), path("*.ffn"), emit: renamed_ffn

--- a/modules/braker_postprocessing.nf
+++ b/modules/braker_postprocessing.nf
@@ -1,64 +1,58 @@
 process BRAKER_POSTPROCESSING {
 
-    tag "${cluster_name}"
+    tag "${genome_name}"
 
     publishDir(
-        path: "${params.outdir}",
-        saveAs: {
-            filename -> {
-                def output_file = file(filename);
-                String genome_name = genome_name;
-                String cluster_prefix = cluster_name.substring(0, cluster_name.length() - 2);
-                def is_rep = genome_name == cluster_name;
-
-                if ( is_rep && ( output_file.extension == "faa" || output_file.extension == "fna" ) ) {
-                    return "species_catalogue/${cluster_prefix}/${genome_name}/genome/${genome_name}.${output_file.extension}";
-                // Used for sanity check purposes
-                } else if ( output_file.extension == "ffn" ) {
-                    return "additional_data/intermediate_files/ffn_files/${output_file.baseName}.${output_file.extension}";
-                // Store the species reps gbk files //
-                } else if ( output_file.extension == "gff" && !is_rep ) {
-                    return "all_genomes/${cluster_prefix}/${cluster_name}/${genome_name}.${output_file.extension}";
-                }
-            }
-        },
-        mode: "copy",
+        path: "${params.outdir}/species_catalogue/${cluster_prefix}/${cluster_name}/genome",
+        pattern: "*.{faa,fna}",
+        saveAs: { filename -> is_rep ? filename : null },
+        mode: 'copy',
         failOnError: true
     )
+
     publishDir(
-        path: "${params.outdir}",
-        saveAs: {
-            filename -> {
-                def output_file = file(filename);
-                if (output_file.extension == "fna") {
-                    return "additional_data/mgyg_genomes/${fasta.baseName}.${output_file.extension}";
-                }
-                return null;
-            }
-        },
-        mode: "copy",
+        path: "${params.outdir}/additional_data/intermediate_files/ffn_files",
+        pattern: "*.ffn",
+        mode: 'copy',
+        failOnError: true
+    )
+
+    publishDir(
+        path: "${params.outdir}/all_genomes/${cluster_prefix}/${cluster_name}",
+        pattern: "*.gff",
+        saveAs: { filename -> is_rep ? null : filename },
+        mode: 'copy',
+        failOnError: true
+    )
+
+    publishDir(
+        path: "${params.outdir}/additional_data/mgyg_genomes",
+        pattern: "*.fna",
+        saveAs: { filename -> "${masked_genome.baseName}.fna" },
+        mode: 'copy',
         failOnError: true
     )
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
     'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/61/6151add1e8ca2e3eaaa65584e3ff9c551eecbfad282dc61f26b5bcbf626b4c06/data' :
     'community.wave.seqera.io/library/pip_biopython:326a6be8fb21b301' }"
-    
-    
+
     label 'process_light'
-    
+
     input:
     tuple val(cluster_name), val(genome_name), path(masked_genome)
     tuple val(genome_name), path(gff3)
     tuple val(genome_name), path(proteins)
     tuple val(genome_name), path(ffn)
-    
+
     output:
-    tuple val(genome_name), path("*.gff"), emit: renamed_gff3  
-    tuple val(genome_name), path("*.faa"), emit: renamed_proteins 
-    tuple val(genome_name), path("*.ffn"), emit: renamed_ffn 
-    
+    tuple val(genome_name), path("*.gff"), emit: renamed_gff3
+    tuple val(genome_name), path("*.faa"), emit: renamed_proteins
+    tuple val(genome_name), path("*.ffn"), emit: renamed_ffn
+
     script:
+    cluster_prefix = cluster_name.substring(0, cluster_name.length() - 2)
+    is_rep = (genome_name == cluster_name)
     """
     rename_and_process_braker_outputs.py \
     --gff ${gff3} \
@@ -70,5 +64,5 @@ process BRAKER_POSTPROCESSING {
     mv renamed*.gff3 ${genome_name}.gff
     mv renamed*.aa ${genome_name}.faa
     mv renamed*.codingseq ${genome_name}.ffn
-    """    
+    """
 }

--- a/modules/detect_ncrna.nf
+++ b/modules/detect_ncrna.nf
@@ -13,7 +13,7 @@ process DETECT_NCRNA {
     )
 
     publishDir(
-        path: "${params.outdir}/species_catalogue/${cluster_rep_prefix}/${genome_accession}/genome",
+        path: "${params.outdir}/species_catalogue/${cluster_rep_prefix}/${cluster_name}/genome",
         pattern: '*_rRNAs.fasta',
         saveAs: { filename ->
             is_rep ? filename : null

--- a/modules/detect_ncrna.nf
+++ b/modules/detect_ncrna.nf
@@ -1,58 +1,30 @@
-
 process DETECT_NCRNA {
 
+    tag "$genome_accession"
     container 'quay.io/microbiome-informatics/genomes-pipeline.detect_rrna:v3.2'
-    
+
     publishDir(
-        path: "${params.outdir}",
-        saveAs: {
-            filename -> {
-                def output_file = file(filename);
-                def is_rep = genome_accession == cluster_name;
-                if ( is_rep && output_file.name.contains("ncrna.deoverlap.tbl" )) {
-                    return "additional_data/ncrna_deoverlapped_species_reps/${genome_accession}.ncrna.deoverlap.tbl";
-                }
-            }
+        path: "${params.outdir}/additional_data/ncrna_deoverlapped_species_reps",
+        pattern: '*.ncrna.deoverlap.tbl',
+        saveAs: { filename ->
+            is_rep ? "${genome_accession}.ncrna.deoverlap.tbl" : null
         },
         mode: 'copy'
     )
-    
+
     publishDir(
-        path: "${params.outdir}",
-        saveAs: {
-            filename -> {
-                if ( !filename.endsWith(".fasta") ) {
-                    return null
-                }
-                def output_file = file(filename);
-                def genome_accession = fasta.baseName.replace("_sm", "");
-                def is_rep = genome_accession == cluster_name;
-                if ( is_rep && output_file.name.contains("_rRNAs") ) {
-                    def cluster_rep_prefix = cluster_name.substring(0, cluster_name.length() - 2);
-                    return "species_catalogue/${cluster_rep_prefix}/${genome_accession}/genome/${genome_accession}_rRNAs.fasta";
-                }
-                return null;
-            }
+        path: "${params.outdir}/species_catalogue/${cluster_rep_prefix}/${genome_accession}/genome",
+        pattern: '*_rRNAs.fasta',
+        saveAs: { filename ->
+            is_rep ? filename : null
         },
         mode: 'copy',
         failOnError: true
     )
 
     publishDir(
-        path: "${params.outdir}",
-        saveAs: {
-            filename -> {
-                if ( !filename.endsWith(".out") ) {
-                    return null;
-                }
-                def output_file = file(filename);
-                def genome_id = fasta.baseName.replace("_sm", "");
-                if ( output_file.name.contains("_rRNAs") ) {
-                    return "additional_data/rRNA_outs/${genome_id}/${output_file.name}";
-                }
-                return null;
-            }
-        },
+        path: "${params.outdir}/additional_data/rRNA_outs/${genome_accession}",
+        pattern: '*_rRNAs.out',
         mode: 'copy',
         failOnError: true
     )
@@ -60,7 +32,7 @@ process DETECT_NCRNA {
     input:
     tuple val(cluster_name), path(fasta)
     path rfam_ncrna_models
-    val(kingdom)
+    val kingdom
 
     output:
     tuple val(genome_accession), path('*.ncrna.deoverlap.tbl'), emit: ncrna_tblout
@@ -68,7 +40,9 @@ process DETECT_NCRNA {
     tuple val(genome_accession), path('*_rRNAs.fasta'), emit: rrna_fasta_results
 
     script:
-    genome_accession = fasta.baseName.replace("_sm", "")
+    genome_accession = fasta.baseName
+    is_rep = (genome_accession == cluster_name)
+    cluster_rep_prefix = cluster_name.substring(0, cluster_name.length() - 2)
     """
     cmscan \
     --cpu ${task.cpus} \
@@ -104,6 +78,5 @@ process DETECT_NCRNA {
     -s cmscan \
     -i ${fasta} \
     -o ${genome_accession}_rRNAs.fasta
-    
     """
 }

--- a/modules/detect_trna.nf
+++ b/modules/detect_trna.nf
@@ -4,24 +4,11 @@
 process DETECT_TRNA {
 
     tag "${genome_name}"
-
     container 'quay.io/microbiome-informatics/genomes-pipeline.detect_rrna:v3.2'
-    
+
     publishDir(
-        path: "${params.outdir}",
-        saveAs: {
-            filename -> {
-                if ( !filename.endsWith(".out") ) {
-                    return null;
-                }
-                def output_file = file(filename);
-                def genome_id = fasta.baseName.replace("_sm", "");
-                if ( output_file.name.contains("_tRNA_20aa") ) {
-                    return "additional_data/rRNA_outs/${genome_id}/${output_file.name}";
-                }
-                return null;
-            }
-        },
+        path: "${params.outdir}/additional_data/rRNA_outs/${genome_name}",
+        pattern: '*_tRNA_20aa.out',
         mode: 'copy',
         failOnError: true
     )
@@ -45,7 +32,7 @@ process DETECT_TRNA {
     # and that causes issues as other detect_trna process will crash when the files are cleaned
     export PROCESSTMP="\$(mktemp -d)"
     export TMPDIR="\${PROCESSTMP}"
-   
+
     # Cleanup on exit, but ignore .nfs* files
     trap '
         if [ -d "\${PROCESSTMP}" ]; then
@@ -68,6 +55,5 @@ process DETECT_TRNA {
     parse_tRNA.py -i ${genome_name}_stats.out -o ${genome_name}_tRNA_20aa.out
 
     echo "Completed"
-
     """
 }

--- a/modules/rename_fasta.nf
+++ b/modules/rename_fasta.nf
@@ -1,4 +1,10 @@
 process RENAME_FASTA {
+    // for some reason this directive does not work when defined in the config file
+    publishDir(
+        path: "${params.outdir}/additional_data/busco",
+        pattern: "renamed_*.summary",
+        mode: 'copy'
+    )
 
     container 'quay.io/microbiome-informatics/genomes-pipeline.python3base:v1.1'
 
@@ -22,7 +28,7 @@ process RENAME_FASTA {
 
     script:
     genomes_prefix = prefix ? prefix : "MGYG"
-    
+
     def args = ""
     if (preassigned_accessions.name != "NO_FILE_PREASSIGNED_ACCS") {
         args += "--map-file ${preassigned_accessions} "

--- a/modules/repeatmasker.nf
+++ b/modules/repeatmasker.nf
@@ -1,5 +1,5 @@
 process REPEAT_MASKER {
-    tag "${genome.baseName}"
+    tag "${genome_name}"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/repeatmasker:4.2.3--pl5321hdfd78af_0' :
@@ -7,11 +7,11 @@ process REPEAT_MASKER {
 
 
     input:
-    tuple val(genome_name), path(genome), path(proteins)
+    tuple val(genome_name), path(genome, stageAs: "${genome_name}_before_masking.fa"), path(proteins)
     tuple val(genome_name), path(library)
 
     output:
-    tuple val(genome_name), path("${genome.baseName}_sm.fa"), emit: masked_genome
+    tuple val(genome_name), path("${genome_name}.fa"), emit: masked_genome
 
     script:
     """
@@ -21,9 +21,8 @@ process REPEAT_MASKER {
     export HOME="\$PWD/.home"
     mkdir -p "\$HOME"
 
-    RepeatMasker -lib ${library} -xsmall ${genome} -pa ${task.cpus}
+    RepeatMasker -lib ${library} -xsmall ${genome_name}_before_masking.fa -pa ${task.cpus}
 
-    mv *.masked "${genome.baseName}_sm.fa"
+    mv *.masked "${genome_name}.fa"
     """
 }
-

--- a/modules/repeatmasker.nf
+++ b/modules/repeatmasker.nf
@@ -2,8 +2,8 @@ process REPEAT_MASKER {
     tag "${genome.baseName}"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://dfam/tetools:latest' :
-        'dfam/tettools:latest' }"
+        'https://depot.galaxyproject.org/singularity/repeatmasker:4.2.3--pl5321hdfd78af_0' :
+        'quay.io/biocontainers/repeatmasker:4.2.3--pl5321hdfd78af_0' }"
 
 
     input:
@@ -11,12 +11,19 @@ process REPEAT_MASKER {
     tuple val(genome_name), path(library)
 
     output:
-    tuple val(genome_name), path("${genome.baseName}_sm.fa"), emit: masked_genome 
+    tuple val(genome_name), path("${genome.baseName}_sm.fa"), emit: masked_genome
 
     script:
     """
+    set -euo pipefail
+
+    # Make HOME unique for this task; RepeatMasker will then use \$HOME/.RepeatMaskerCache
+    export HOME="\$PWD/.home"
+    mkdir -p "\$HOME"
+
     RepeatMasker -lib ${library} -xsmall ${genome} -pa ${task.cpus}
 
     mv *.masked "${genome.baseName}_sm.fa"
     """
 }
+

--- a/modules/repeatmasker.nf
+++ b/modules/repeatmasker.nf
@@ -1,5 +1,5 @@
 process REPEAT_MASKER {
-    tag "${genome_name}"
+    tag "${genome.baseName}"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/repeatmasker:4.2.3--pl5321hdfd78af_0' :
@@ -7,11 +7,11 @@ process REPEAT_MASKER {
 
 
     input:
-    tuple val(genome_name), path(genome, stageAs: "${genome_name}_before_masking.fa"), path(proteins)
+    tuple val(genome_name), path(genome, stageAs: "input/*"), path(proteins)
     tuple val(genome_name), path(library)
 
     output:
-    tuple val(genome_name), path("${genome_name}.fa"), emit: masked_genome
+    tuple val(genome_name), path("${genome.baseName}.fa"), emit: masked_genome
 
     script:
     """
@@ -21,8 +21,8 @@ process REPEAT_MASKER {
     export HOME="\$PWD/.home"
     mkdir -p "\$HOME"
 
-    RepeatMasker -lib ${library} -xsmall ${genome_name}_before_masking.fa -pa ${task.cpus}
+    RepeatMasker -lib ${library} -xsmall ${genome} -pa ${task.cpus}
 
-    mv *.masked "${genome_name}.fa"
+    mv "${genome}.masked" "${genome.baseName}.fa"
     """
 }

--- a/modules/repeatmodeler.nf
+++ b/modules/repeatmodeler.nf
@@ -12,7 +12,7 @@ process REPEAT_MODELER {
     output:
     tuple val(genome.baseName), path("*families.fa"), emit: repeat_families, optional: true
     tuple val(genome.baseName), path("*families.stk"), emit: repeat_aligment, optional: true
-    tuple val(genome.baseName), path("*rmod.log"), emit: logile
+    tuple val(genome.baseName), path("*rmod.log"), emit: logile, optional: true
 
     script:
     """

--- a/modules/repeatmodeler.nf
+++ b/modules/repeatmodeler.nf
@@ -15,7 +15,7 @@ process REPEAT_MODELER {
 
     script:
     """
-
+    set +e
     BuildDatabase -name ${genome.baseName} ${genome}
 
     RepeatModeler -database ${genome.baseName} -threads ${task.cpus} -LTRStruct

--- a/modules/repeatmodeler.nf
+++ b/modules/repeatmodeler.nf
@@ -2,8 +2,8 @@ process REPEAT_MODELER {
     tag "${genome.baseName}"
 
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://dfam/tetools:latest' :
-        'dfam/tettools:latest' }"
+        'https://depot.galaxyproject.org/singularity/repeatmodeler:2.0.7--pl5321hdfd78af_0':
+        'quay.io/biocontainers/repeatmodeler:2.0.7--pl5321hdfd78af_0' }"
 
 
     input:

--- a/modules/repeatmodeler.nf
+++ b/modules/repeatmodeler.nf
@@ -5,7 +5,6 @@ process REPEAT_MODELER {
         'https://depot.galaxyproject.org/singularity/repeatmodeler:2.0.7--pl5321hdfd78af_0':
         'quay.io/biocontainers/repeatmodeler:2.0.7--pl5321hdfd78af_0' }"
 
-
     input:
     tuple val(cluster), path(genome), path(proteins)
 
@@ -16,8 +15,20 @@ process REPEAT_MODELER {
 
     script:
     """
+
     BuildDatabase -name ${genome.baseName} ${genome}
 
     RepeatModeler -database ${genome.baseName} -threads ${task.cpus} -LTRStruct
+    status=\$?
+
+    if [[ \$status -ne 0 ]]; then
+        if grep -Fq "Refining 0 families..." .command.log && \
+            grep -Fq "cat: can't open" .command.log   && \
+            grep -Fq "refined-cons.fa" .command.log; then
+            echo "RepeatModeler hit known empty-refinement failure; treating as non-fatal."
+            exit 0
+        fi
+        exit \$status
+    fi
     """
 }

--- a/modules/repeatmodeler.nf
+++ b/modules/repeatmodeler.nf
@@ -10,8 +10,8 @@ process REPEAT_MODELER {
     tuple val(cluster), path(genome), path(proteins)
 
     output:
-    tuple val(genome.baseName), path("*families.fa"), emit: repeat_families
-    tuple val(genome.baseName), path("*families.stk"), emit: repeat_aligment
+    tuple val(genome.baseName), path("*families.fa"), emit: repeat_families, optional: true
+    tuple val(genome.baseName), path("*families.stk"), emit: repeat_aligment, optional: true
     tuple val(genome.baseName), path("*rmod.log"), emit: logile
 
     script:

--- a/nextflow.config
+++ b/nextflow.config
@@ -163,6 +163,7 @@ profiles {
             enabled = true
             autoMounts = true
             cacheDir = params.singularity_cachedir
+            pullTimeout = "1h"
         }
 
         process {

--- a/subworkflows/annotate_eukaryotes.nf
+++ b/subworkflows/annotate_eukaryotes.nf
@@ -8,12 +8,12 @@ include { EGGNOG_MAPPER as EGGNOG_MAPPER_ANNOTATIONS_PER_GENOME } from '../modul
 
 workflow ANNOTATE_EUKARYOTES {
     take:
-        cluster_reps_faas
-        interproscan_db
-        eggnog_db
-        eggnog_diamond_db
-        eggnog_data_dir
-        
+        cluster_reps_faas   // channel: [ val(cluster_name), path(faa) ] - channel containing proteins of the cluster representatives
+        interproscan_db     // val(path) - to InterProScan database
+        eggnog_db           // val(path) - to eggNOG database
+        eggnog_diamond_db   // val(path) - to eggNOG diamond database
+        eggnog_data_dir     // val(path) - to eggNOG database dir
+
     main:
         IPS_PER_GENOME(
             cluster_reps_faas,
@@ -39,9 +39,8 @@ workflow ANNOTATE_EUKARYOTES {
             eggnog_diamond_db,
             eggnog_data_dir
         )
-    
+
     emit:
         ips_annotation_tsvs = IPS_PER_GENOME.out.ips_annotations
         eggnog_annotation_tsvs = EGGNOG_MAPPER_ANNOTATIONS_PER_GENOME.out.annotations
 }
-        

--- a/subworkflows/detect_rna_swf.nf
+++ b/subworkflows/detect_rna_swf.nf
@@ -3,27 +3,33 @@
 */
 
 include { DETECT_NCRNA } from '../modules/detect_ncrna'
-include { DETECT_TRNA } from '../modules/detect_trna'
+include { DETECT_TRNA  } from '../modules/detect_trna'
 
 workflow DETECT_RNA {
+
     take:
-        fnas
-        accessions_with_domains
-        rfam_ncrna_models
-        kingdom
+    fnas                      // channel: [ val(cluster_name), path(fasta) ] - softmasked genomes
+    accessions_with_domains   // channel: [ val(genome_name), val(domain) ] - assigned domain for each genome
+    rfam_ncrna_models         // val(path) - to RFAM ncRNA models
+    kingdom                   // val(kingdom) - either "eukaryotes" or "prokaryotes"
+
     main:
-        DETECT_TRNA(
-            fnas.map(it -> [it[1].baseName.replace("_sm", ""), it[1]]).join(
-                accessions_with_domains, remainder: true
-            ).filter{  it -> it[1] != null } // remove genomes that were filtered out during QC and don't have an fna
-        )
-       DETECT_NCRNA(
-            fnas,
-            rfam_ncrna_models,
-            kingdom
-       )
+    DETECT_TRNA(
+        fnas.map{ _cluster_name, genome_fasta -> [genome_fasta.baseName, genome_fasta] }
+            .join(accessions_with_domains)
+            .filter { _cluster_name, genome_fasta, _domain -> // TODO: check if this filter is necessary
+                genome_fasta != null  // remove genomes that were filtered out during QC and don't have an fna
+            }
+    )
+
+    DETECT_NCRNA(
+        fnas,
+        rfam_ncrna_models,
+        kingdom
+    )
+
     emit:
-        ncrna_tblout = DETECT_NCRNA.out.ncrna_tblout
-        rrna_outs = DETECT_NCRNA.out.rrna_out_results.join(DETECT_TRNA.out.trna_count)
-        trna_gff = DETECT_TRNA.out.trna_gff
+    ncrna_tblout = DETECT_NCRNA.out.ncrna_tblout
+    rrna_outs = DETECT_NCRNA.out.rrna_out_results.join(DETECT_TRNA.out.trna_count)
+    trna_gff = DETECT_TRNA.out.trna_gff
 }

--- a/subworkflows/detect_rna_swf.nf
+++ b/subworkflows/detect_rna_swf.nf
@@ -17,7 +17,7 @@ workflow DETECT_RNA {
     DETECT_TRNA(
         fnas.map{ _cluster_name, genome_fasta -> [genome_fasta.baseName, genome_fasta] }
             .join(accessions_with_domains)
-            .filter { _cluster_name, genome_fasta, _domain -> // TODO: check if this filter is necessary
+            .filter { _genome_name, genome_fasta, _domain -> // TODO: check if this filter is necessary
                 genome_fasta != null  // remove genomes that were filtered out during QC and don't have an fna
             }
     )

--- a/subworkflows/eukaryotic_gene_annotation.nf
+++ b/subworkflows/eukaryotic_gene_annotation.nf
@@ -4,7 +4,7 @@
 
 include { REPEAT_MODELER } from '../modules/repeatmodeler.nf'
 include { REPEAT_MASKER } from '../modules/repeatmasker.nf'
-include { BRAKER } from '../modules/braker.nf' 
+include { BRAKER } from '../modules/braker.nf'
 include { BRAKER_POSTPROCESSING } from '../modules/braker_postprocessing.nf'
 
 
@@ -17,51 +17,67 @@ workflow EUK_GENE_CALLING {
             tuple_genome_proteins
         )
 
-        tuple_genome_proteins_nocluster = tuple_genome_proteins.map { cluster, genome, proteins -> tuple(genome.baseName, genome, proteins) }
-        cluster_name_ch = tuple_genome_proteins.map { cluster, genome, proteins -> tuple(genome.baseName, cluster) }
-        
-        ch_repeat_masker = Channel.empty()
-
-        tuple_genome_proteins_nocluster.join( REPEAT_MODELER.out.repeat_families ).multiMap { genome_name, genome, prot_evidence, repeat_families ->
-            genome_proteins: [genome_name, genome, prot_evidence]
-            repeat_families: [genome_name, repeat_families]
-        }.set {
-            ch_repeat_masker
+        tuple_genome_proteins_nocluster = tuple_genome_proteins.map { _cluster, genome, proteins ->
+            tuple(genome.baseName, genome, proteins)
         }
+        cluster_name_ch = tuple_genome_proteins.map { cluster, genome, _proteins ->
+            tuple(genome.baseName, cluster)
+        }
+
+        // Use join with remainder to handle genomes without repeat families
+        genomes_after_repeatmodeler = tuple_genome_proteins_nocluster
+            .join(REPEAT_MODELER.out.repeat_families, remainder: true)
+            .branch { genome_name, genome, prot_evidence, repeat_families ->
+                with_repeats: repeat_families != null
+                    return tuple(genome_name, genome, prot_evidence, repeat_families)
+                without_repeats: true
+                    return tuple(genome_name, genome)
+            }
+
+        // Process genomes with repeats through REPEAT_MASKER
+        ch_repeat_masker_input = genomes_after_repeatmodeler.with_repeats
+            .multiMap { genome_name, genome, prot_evidence, repeat_families ->
+                genome_proteins: tuple(genome_name, genome, prot_evidence)
+                repeat_families: tuple(genome_name, repeat_families)
+            }
 
         REPEAT_MASKER(
-            ch_repeat_masker.genome_proteins, 
-            ch_repeat_masker.repeat_families, 
+            ch_repeat_masker_input.genome_proteins,
+            ch_repeat_masker_input.repeat_families
         )
 
-        ch_repeat_modeler = Channel.empty()
+        // Combine masked genomes with unmasked genomes
+        def all_genomes_for_braker = REPEAT_MASKER.out.masked_genome
+            .mix(genomes_after_repeatmodeler.without_repeats)
 
-        tuple_genome_proteins_nocluster.join( REPEAT_MASKER.out.masked_genome ).multiMap { genome_name, genome, prot_evidence, masked_genome ->
-            genome_proteins: [genome_name, prot_evidence]
-            masked_genome: [genome_name, masked_genome]
-        }.set {
-            ch_repeat_modeler
-        }
+        // Prepare channels for BRAKER
+        ch_braker_input = tuple_genome_proteins_nocluster
+            .map { genome_name, _genome, prot_evidence ->
+                tuple(genome_name, prot_evidence)
+            }
+            .join(all_genomes_for_braker)
+            .multiMap { genome_name, prot_evidence, genome ->
+                masked_genome: tuple(genome_name, genome)
+                genome_proteins: tuple(genome_name, prot_evidence)
+            }
 
         BRAKER(
-            ch_repeat_modeler.masked_genome,
-            ch_repeat_modeler.genome_proteins
+            ch_braker_input.masked_genome,
+            ch_braker_input.genome_proteins
         )
 
-        ch_braker = Channel.empty()
-        cluster_name_ch
+        ch_braker = cluster_name_ch
             .join( tuple_genome_proteins_nocluster )
             .join( BRAKER.out.gff3 )
             .join( BRAKER.out.proteins )
             .join( BRAKER.out.ffn )
-            .join( ch_repeat_modeler.masked_genome ).multiMap { genome_name, cluster, genome, prot_evidence, gff, faa, ffn, masked_genome ->
+            .join( all_genomes_for_braker )
+            .multiMap { genome_name, cluster, _genome, _prot_evidence, gff, faa, ffn, masked_genome ->
                 genome: [cluster, genome_name, masked_genome]
                 gff: [genome_name, gff]
                 faa: [genome_name, faa]
                 ffn: [genome_name, ffn]
-        }.set {
-            ch_braker
-        }
+            }
 
         BRAKER_POSTPROCESSING(
             ch_braker.genome,
@@ -69,20 +85,18 @@ workflow EUK_GENE_CALLING {
             ch_braker.faa,
             ch_braker.ffn
         )
-        
-        output_ch = Channel.empty()
-        cluster_name_ch
+
+        output_ch = cluster_name_ch
             .join( BRAKER_POSTPROCESSING.out.renamed_gff3 )
             .join( BRAKER_POSTPROCESSING.out.renamed_proteins )
             .join( BRAKER_POSTPROCESSING.out.renamed_ffn )
-            .join( ch_repeat_modeler.masked_genome ).multiMap { genome_name, cluster_name, gff, faa, ffn, masked_genome ->
+            .join( all_genomes_for_braker )
+            .multiMap { _genome_name, cluster_name, gff, faa, ffn, masked_genome ->
                 masked_genome: [cluster_name, masked_genome]
                 gff: [cluster_name, gff]
                 faa: [cluster_name, faa]
                 ffn: [cluster_name, ffn]
-        }.set {
-            output_ch
-        }
+            }
 
     emit:
         gffs = output_ch.gff


### PR DESCRIPTION
PR resolves multiple issues from https://embl.atlassian.net/browse/EMG-7798:
- Genome can contain no repeats, in this case RepeatModeler doesn't produce output files. All its outputs were made optional and flow changed to split repetitive and no repetitive genomes into 2 channels and merge them before gene prediction. 
- HOME variable inside RepeatMasker module is redefined to local tmp folder to prevent RepeatMasker from caching into user's HOME. 
- Containers that used tag `latest` replaced
- README updated, example of Datascout samplesheet added